### PR TITLE
Idle/Duty Fix

### DIFF
--- a/FaderPlugin/Plugin.cs
+++ b/FaderPlugin/Plugin.cs
@@ -243,8 +243,14 @@ namespace FaderPlugin
                     return true;
                 }
 
-                var value = this._configuration.GetSetting(element, this.currentState);
-                return value switch
+                var setting = this._configuration.GetSetting(element, this.currentState);
+
+                // If an element is set to skip while in a duty fallback to idle state.
+                if(setting == ConfigElementSetting.Skip && this.currentState == FaderState.Duty) {
+                    setting = this._configuration.GetSetting(element, FaderState.Idle);
+                }
+
+                return setting switch
                 {
                     ConfigElementSetting.Show => true,
                     ConfigElementSetting.Hide => false,


### PR DESCRIPTION
Currently if an element is set to show/hide while in combat, set to the opposite while idle and skipped while in duty the element will lock into its combat state for the duration of a duty.

This fix uses the idle state as a fallback when in a duty and duty state is set to skip.

Fixes #31.