### PR TITLE
Add prevent interaction setting

### DIFF
--- a/FaderPlugin/Config/Configuration.cs
+++ b/FaderPlugin/Config/Configuration.cs
@@ -10,11 +10,12 @@ namespace FaderPlugin.Config
     {
         public event Action OnSaved;
 
-        public int                                                                       Version              { get; set; } = 4;
-        public Dictionary<FaderState, Dictionary<ConfigElementId, ConfigElementSetting>> ElementsTable        { get; set; }
-        public long                                                                      IdleTransitionDelay  { get; set; } = 2000;
-        public int                                                                       OverrideKey          { get; set; } = 0x12;
-        public bool                                                                      FocusOnHotbarsUnlock { get; set; } = false;
+        public int                                                                       Version                  { get; set; } = 4;
+        public Dictionary<FaderState, Dictionary<ConfigElementId, ConfigElementSetting>> ElementsTable            { get; set; }
+        public long                                                                      IdleTransitionDelay      { get; set; } = 2000;
+        public int                                                                       OverrideKey              { get; set; } = 0x12;
+        public bool                                                                      FocusOnHotbarsUnlock     { get; set; } = false;
+        public bool                                                                      PreventHiddenInteraction { get; set; } = false;
 
         [NonSerialized]
         private DalamudPluginInterface pluginInterface;

--- a/FaderPlugin/Plugin.cs
+++ b/FaderPlugin/Plugin.cs
@@ -251,7 +251,7 @@ namespace FaderPlugin
                     ConfigElementSetting.Skip => null,
                     _                         => null,
                 };
-            });
+            }, this._configuration.PreventHiddenInteraction);
         }
     }
 }

--- a/FaderPlugin/PluginUI.cs
+++ b/FaderPlugin/PluginUI.cs
@@ -156,6 +156,16 @@ namespace FaderPlugin
                 ImGui.Text("Always User Focus when hotbars are unlocked");
                 ImGuiHelpTooltip("When hotbars or crossbars are unlocked always setup to the UserFocus column.");
 
+                var preventHiddenInteraction = configuration.PreventHiddenInteraction;
+                if(ImGui.Checkbox("##prevent_hidden_interaction", ref preventHiddenInteraction)) {
+                    this.configuration.PreventHiddenInteraction = preventHiddenInteraction;
+                    this.configuration.Save();
+                }
+
+                ImGui.SameLine();
+                ImGui.Text("Prevent interaction with hidden elements");
+                ImGuiHelpTooltip("Moves elements offscreen when hidden to prevent interaction. It is recommended you backup your layout before enabling this.");
+
                 var idleDelay = (float)TimeSpan.FromMilliseconds(configuration.IdleTransitionDelay).TotalSeconds;
                 ImGui.Text("Idle transition delay:");
                 ImGui.SameLine();


### PR DESCRIPTION
Moves hidden items off screen to prevent interaction. Restores original positions when shown again or when the game is closed.

Fixes #27.