### PR TITLE
Update job gauges visibility after job change

### DIFF
--- a/FaderPlugin/Addon.cs
+++ b/FaderPlugin/Addon.cs
@@ -110,6 +110,6 @@ public static unsafe class Addon {
 
     public static bool InSanctuary()
     {
-        return GameMain.IsInSanctuary();
+        return TerritoryInfo.Instance()->InSanctuary;
     }
 }

--- a/FaderPlugin/FaderPlugin.csproj
+++ b/FaderPlugin/FaderPlugin.csproj
@@ -26,7 +26,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="DalamudPackager" Version="11.0.0" />
 		<Reference Include="FFXIVClientStructs">
 			<HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>
 			<Private>false</Private>

--- a/FaderPlugin/FaderPlugin.json
+++ b/FaderPlugin/FaderPlugin.json
@@ -6,6 +6,7 @@
   "InternalName": "faderPlugin",
   "RepoUrl": "https://github.com/shdwp/xivFaderPlugin",
   "ApplicableVersion": "any",
+  "DalamudApiLevel": 11,
   "Tags": [
     "UI"
   ],


### PR DESCRIPTION
When job gauges are configured to be hidden by default, switching between different jobs does not hide the job gauges until another state change occurs regardless of whether delay is enabled. This seems to be a timing issue even when `AtkUnitBase.SetPosition` is called.

This change adds a short single-fire timer when job is changed that when expired signals that job gauges position can be set. It then triggers a state change to update addon visibility.